### PR TITLE
Add choice or active variables in the RunTest notifications

### DIFF
--- a/SkyLab/SkyLab.h
+++ b/SkyLab/SkyLab.h
@@ -43,3 +43,6 @@
 extern NSString * const SkyLabWillRunTestNotification;
 extern NSString * const SkyLabDidRunTestNotification;
 extern NSString * const SkyLabDidResetTestNotification;
+
+extern NSString * const SkyLabChoiceKey;
+extern NSString * const SkyLabActiveVariablesKey;

--- a/SkyLab/SkyLab.m
+++ b/SkyLab/SkyLab.m
@@ -27,6 +27,9 @@ NSString * const SkyLabWillRunTestNotification = @"SkyLabWillRunTestNotification
 NSString * const SkyLabDidRunTestNotification = @"SkyLabDidRunTestNotification";
 NSString * const SkyLabDidResetTestNotification = @"SkyLabDidResetTestNotification";
 
+NSString * const SkyLabChoiceKey = @"SkyLabChoice";
+NSString * const SkyLabActiveVariablesKey = @"SkyLabActiveVariables";
+
 static NSString * SLUserDefaultsKeyForTestName(NSString *name) {
     static NSString * const kSLUserDefaultsKeyFormat = @"SkyLab-%@";
 
@@ -128,9 +131,11 @@ static BOOL SLRandomBinaryChoice() {
     [[NSUserDefaults standardUserDefaults] setObject:choice forKey:SLUserDefaultsKeyForTestName(name)];
     [[NSUserDefaults standardUserDefaults] synchronize];
     
-    [[NSNotificationCenter defaultCenter] postNotificationName:SkyLabWillRunTestNotification object:name];
+    NSDictionary *userInfo = [NSDictionary dictionaryWithObject:choice forKey:SkyLabChoiceKey];
+    
+    [[NSNotificationCenter defaultCenter] postNotificationName:SkyLabWillRunTestNotification object:name userInfo:userInfo];
     block(choice);
-    [[NSNotificationCenter defaultCenter] postNotificationName:SkyLabDidRunTestNotification object:name];
+    [[NSNotificationCenter defaultCenter] postNotificationName:SkyLabDidRunTestNotification object:name userInfo:userInfo];
 }
 
 + (void)multivariateTestWithName:(NSString *)name
@@ -170,9 +175,11 @@ static BOOL SLRandomBinaryChoice() {
     [[NSUserDefaults standardUserDefaults] setObject:[activeVariables allObjects] forKey:SLUserDefaultsKeyForTestName(name)];
     [[NSUserDefaults standardUserDefaults] synchronize];
     
-    [[NSNotificationCenter defaultCenter] postNotificationName:SkyLabWillRunTestNotification object:name];
+    NSDictionary *userInfo = [NSDictionary dictionaryWithObject:activeVariables forKey:SkyLabActiveVariablesKey];
+    
+    [[NSNotificationCenter defaultCenter] postNotificationName:SkyLabWillRunTestNotification object:name userInfo:userInfo];
     block(activeVariables);
-    [[NSNotificationCenter defaultCenter] postNotificationName:SkyLabDidRunTestNotification object:name];
+    [[NSNotificationCenter defaultCenter] postNotificationName:SkyLabDidRunTestNotification object:name userInfo:userInfo];
 }
 
 


### PR DESCRIPTION
I include the choice/variable names in the notification so I can track which variation the user has been exposed to to my reporting service.
